### PR TITLE
Add conversation reset feature to AI chat interface

### DIFF
--- a/lib/features/chat/pages/chat_page.dart
+++ b/lib/features/chat/pages/chat_page.dart
@@ -16,6 +16,33 @@ class ChatPage extends ConsumerWidget {
     _controller.clear();
   }
 
+  void _resetChat(WidgetRef ref) {
+    showDialog(
+      context: ref.context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Confirm Reset'),
+          content: const Text('Are you sure you want to reset the chat?'),
+          actions: <Widget>[
+            TextButton(
+              child: const Text('Cancel'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+            TextButton(
+              child: const Text('Reset'),
+              onPressed: () {
+                ref.read(chatNotifierProvider.notifier).resetChat();
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final messages = ref.watch(chatNotifierProvider);
@@ -24,6 +51,12 @@ class ChatPage extends ConsumerWidget {
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         title: const Text('AI English Chat'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () => _resetChat(ref),
+          ),
+        ],
       ),
       body: Column(
         children: [

--- a/lib/features/chat/pages/chat_page.dart
+++ b/lib/features/chat/pages/chat_page.dart
@@ -1,4 +1,5 @@
 import 'package:ai_english/features/chat/pages/widgets/message_bubble.dart';
+import 'package:ai_english/features/chat/pages/widgets/reset_alert_dialog.dart';
 import 'package:ai_english/features/chat/providers/chat_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -20,25 +21,9 @@ class ChatPage extends ConsumerWidget {
     showDialog(
       context: ref.context,
       builder: (BuildContext context) {
-        return AlertDialog(
-          title: const Text('Confirm Reset'),
-          content: const Text('Are you sure you want to reset the chat?'),
-          actions: <Widget>[
-            TextButton(
-              child: const Text('Cancel'),
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-            ),
-            TextButton(
-              child: const Text('Reset'),
-              onPressed: () {
-                ref.read(chatNotifierProvider.notifier).resetChat();
-                Navigator.of(context).pop();
-              },
-            ),
-          ],
-        );
+        return resetAlertDialog(context, () {
+          ref.read(chatNotifierProvider.notifier).resetChat();
+        });
       },
     );
   }
@@ -81,7 +66,7 @@ class ChatPage extends ConsumerWidget {
                     maxLines: 2,
                     controller: _controller,
                     decoration: const InputDecoration(
-                      hintText: 'メッセージを入力...',
+                      hintText: 'Type a message...',
                       border: InputBorder.none,
                     ),
                     onSubmitted: (value) => _sendMessage(ref),

--- a/lib/features/chat/pages/widgets/reset_alert_dialog.dart
+++ b/lib/features/chat/pages/widgets/reset_alert_dialog.dart
@@ -1,0 +1,25 @@
+import 'package:ai_english/features/chat/providers/chat_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+Widget resetAlertDialog(BuildContext context, Function onReset) {
+  return AlertDialog(
+    title: const Text('Confirm Reset'),
+    content: const Text('Are you sure you want to reset the chat?'),
+    actions: <Widget>[
+      TextButton(
+        child: const Text('Cancel'),
+        onPressed: () {
+          Navigator.of(context).pop();
+        },
+      ),
+      TextButton(
+        child: const Text('Reset'),
+        onPressed: () {
+          onReset();
+          Navigator.of(context).pop();
+        },
+      ),
+    ],
+  );
+}

--- a/lib/features/chat/pages/widgets/reset_alert_dialog.dart
+++ b/lib/features/chat/pages/widgets/reset_alert_dialog.dart
@@ -1,6 +1,4 @@
-import 'package:ai_english/features/chat/providers/chat_provider.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 Widget resetAlertDialog(BuildContext context, Function onReset) {
   return AlertDialog(

--- a/lib/features/chat/providers/chat_provider.dart
+++ b/lib/features/chat/providers/chat_provider.dart
@@ -96,7 +96,7 @@ class ChatNotifier extends _$ChatNotifier {
       state = [
         ...state,
         Message(
-          text: "エラーが発生しました: $e",
+          text: "Unexpected error occurred while sending message: $e",
           isUser: false,
           createdAt: DateTime.now(),
         ),
@@ -119,7 +119,7 @@ class ChatNotifier extends _$ChatNotifier {
       state = [
         ...state,
         Message(
-          text: "リセット中にエラーが発生しました: $e",
+          text: "unexpected error occurred while resetting chat: $e",
           isUser: false,
           createdAt: DateTime.now(),
         ),

--- a/lib/features/chat/providers/chat_provider.g.dart
+++ b/lib/features/chat/providers/chat_provider.g.dart
@@ -6,7 +6,7 @@ part of 'chat_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$chatNotifierHash() => r'cbe1c9fe6eed4b2eb815c1b832609b544c2bc82b';
+String _$chatNotifierHash() => r'1158271d333d7fdd887359290ea6d445e19ad114';
 
 /// See also [ChatNotifier].
 @ProviderFor(ChatNotifier)

--- a/lib/features/chat/providers/chat_provider.g.dart
+++ b/lib/features/chat/providers/chat_provider.g.dart
@@ -6,7 +6,7 @@ part of 'chat_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$chatNotifierHash() => r'1158271d333d7fdd887359290ea6d445e19ad114';
+String _$chatNotifierHash() => r'43392ed9131c72b22b3b9a01541ceeb4ea3e7045';
 
 /// See also [ChatNotifier].
 @ProviderFor(ChatNotifier)

--- a/memo.txt
+++ b/memo.txt
@@ -1,2 +1,4 @@
 adb reverse tcp:8080 tcp:8080
 コマンドをPowerShellで実行
+
+flutter pub run build_runner watch --delete-conflicting-outputs

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -651,7 +651,7 @@ packages:
     source: hosted
     version: "1.4.0"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   # HTTPクライアントライブラリ。API呼び出しやネットワーク通信を効率化。
   dio: ^5.8.0+1
   flutter_tts: ^4.2.2
+  uuid: ^4.5.1
 
 dev_dependencies:
   # Flutterのテストフレームワーク。単体テストやウィジェットテストの実行に使用。


### PR DESCRIPTION
Add a reset feature to the AI chat interface.

* **Chat Page (`lib/features/chat/pages/chat_page.dart`)**
  - Add a "Reset" button to the AppBar.
  - Implement a confirmation dialog before performing the reset action.
  - Call the `resetChat` method from `chatNotifierProvider` when reset is confirmed.

* **Chat Provider (`lib/features/chat/providers/chat_provider.dart`)**
  - Add a `resetChat` method to clear chat history and generate a new session ID.
  - Update the `resetChat` method to initialize a fresh chat state.
  - Add error handling for failed resets.

