### PR TITLE
Implement chat history audio playback feature using flutter_tts

### DIFF
--- a/lib/core/utils/provider/tts_provider.dart
+++ b/lib/core/utils/provider/tts_provider.dart
@@ -27,4 +27,32 @@ class TtsNotifier extends AsyncNotifier<FlutterTts> {
     final tts = await future;
     await tts.speak(text);
   }
+
+  Future<void> speakChatHistory(List<String> chatHistory) async {
+    final tts = await future;
+    for (String message in chatHistory) {
+      await tts.speak(message);
+      await tts.awaitSpeakCompletion(true);
+    }
+  }
+
+  Future<void> pause() async {
+    final tts = await future;
+    await tts.pause();
+  }
+
+  Future<void> resume() async {
+    final tts = await future;
+    await tts.resume();
+  }
+
+  Future<void> stop() async {
+    final tts = await future;
+    await tts.stop();
+  }
+
+  Future<void> setPlaybackPosition(double position) async {
+    final tts = await future;
+    await tts.setProgress(position);
+  }
 }

--- a/lib/core/utils/provider/tts_provider.dart
+++ b/lib/core/utils/provider/tts_provider.dart
@@ -1,3 +1,5 @@
+import 'package:ai_english/features/chat/models/message.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_tts/flutter_tts.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -13,8 +15,20 @@ class TtsNotifier extends AsyncNotifier<FlutterTts> {
     await tts.setLanguage('en-US');
     await tts.setSpeechRate(0.6);
     await tts.setPitch(1.0);
+
     await tts.awaitSpeakCompletion(false);
     await tts.awaitSynthCompletion(true);
+    await tts.setEngine('com.google.android.tts'); // Multilingual TTS
+    // 利用可能な音声を取得
+    final voices = await tts.getVoices;
+    if (kDebugMode) {
+      debugPrint('使用可能なボイス: $voices');
+    }
+
+    final engines = await tts.getEngines;
+    if (kDebugMode) {
+      debugPrint('使用可能なエンジン: $engines');
+    }
 
     ref.onDispose(() {
       tts.stop();
@@ -23,36 +37,36 @@ class TtsNotifier extends AsyncNotifier<FlutterTts> {
     return tts;
   }
 
-  Future<void> speak(String text) async {
+  Future<void> speak(Message message) async {
     final tts = await future;
-    await tts.speak(text);
+
+    // 話者に応じて音声を設定
+    if (message.isUser) {
+      // 男性ボイスを設定
+      await tts.setVoice({
+        "name": "en-us-x-tpd-local", // 別の男性ボイス
+        "locale": "en-US"
+      });
+    } else {
+      await tts.setVoice({
+        "name": "en-us-x-sfg-local", // 別の男性ボイス
+        "locale": "en-US"
+      });
+    }
+    await tts.speak(message.text);
   }
 
-  Future<void> speakChatHistory(List<String> chatHistory) async {
+  Future<void> speakChatHistory(List<Message> chatHistory) async {
     final tts = await future;
-    for (String message in chatHistory) {
-      await tts.speak(message);
+
+    for (Message message in chatHistory) {
+      await speak(message);
       await tts.awaitSpeakCompletion(true);
     }
-  }
-
-  Future<void> pause() async {
-    final tts = await future;
-    await tts.pause();
-  }
-
-  Future<void> resume() async {
-    final tts = await future;
-    await tts.resume();
   }
 
   Future<void> stop() async {
     final tts = await future;
     await tts.stop();
-  }
-
-  Future<void> setPlaybackPosition(double position) async {
-    final tts = await future;
-    await tts.setProgress(position);
   }
 }

--- a/lib/features/chat/pages/chat_page.dart
+++ b/lib/features/chat/pages/chat_page.dart
@@ -31,20 +31,8 @@ class ChatPage extends ConsumerWidget {
   }
 
   void _playChatHistory(WidgetRef ref) {
-    final chatHistory = ref.read(chatNotifierProvider.notifier).state.map((message) => message.text).toList();
+    final chatHistory = ref.read(chatNotifierProvider).toList();
     ref.read(ttsNotifierProvider.notifier).speakChatHistory(chatHistory);
-  }
-
-  void _pauseTTS(WidgetRef ref) {
-    ref.read(ttsNotifierProvider.notifier).pause();
-  }
-
-  void _resumeTTS(WidgetRef ref) {
-    ref.read(ttsNotifierProvider.notifier).resume();
-  }
-
-  void _stopTTS(WidgetRef ref) {
-    ref.read(ttsNotifierProvider.notifier).stop();
   }
 
   @override
@@ -63,18 +51,6 @@ class ChatPage extends ConsumerWidget {
           IconButton(
             icon: const Icon(Icons.play_arrow),
             onPressed: () => _playChatHistory(ref),
-          ),
-          IconButton(
-            icon: const Icon(Icons.pause),
-            onPressed: () => _pauseTTS(ref),
-          ),
-          IconButton(
-            icon: const Icon(Icons.play_arrow),
-            onPressed: () => _resumeTTS(ref),
-          ),
-          IconButton(
-            icon: const Icon(Icons.stop),
-            onPressed: () => _stopTTS(ref),
           ),
         ],
       ),
@@ -98,7 +74,6 @@ class ChatPage extends ConsumerWidget {
               children: [
                 Expanded(
                   child: TextField(
-                    maxLines: 2,
                     controller: _controller,
                     decoration: const InputDecoration(
                       hintText: 'Type a message...',

--- a/lib/features/chat/pages/chat_page.dart
+++ b/lib/features/chat/pages/chat_page.dart
@@ -3,6 +3,7 @@ import 'package:ai_english/features/chat/pages/widgets/reset_alert_dialog.dart';
 import 'package:ai_english/features/chat/providers/chat_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ai_english/core/utils/provider/tts_provider.dart';
 
 class ChatPage extends ConsumerWidget {
   ChatPage({super.key});
@@ -23,9 +24,27 @@ class ChatPage extends ConsumerWidget {
       builder: (BuildContext context) {
         return resetAlertDialog(context, () {
           ref.read(chatNotifierProvider.notifier).resetChat();
+          ref.read(ttsNotifierProvider.notifier).stop();
         });
       },
     );
+  }
+
+  void _playChatHistory(WidgetRef ref) {
+    final chatHistory = ref.read(chatNotifierProvider.notifier).state.map((message) => message.text).toList();
+    ref.read(ttsNotifierProvider.notifier).speakChatHistory(chatHistory);
+  }
+
+  void _pauseTTS(WidgetRef ref) {
+    ref.read(ttsNotifierProvider.notifier).pause();
+  }
+
+  void _resumeTTS(WidgetRef ref) {
+    ref.read(ttsNotifierProvider.notifier).resume();
+  }
+
+  void _stopTTS(WidgetRef ref) {
+    ref.read(ttsNotifierProvider.notifier).stop();
   }
 
   @override
@@ -40,6 +59,22 @@ class ChatPage extends ConsumerWidget {
           IconButton(
             icon: const Icon(Icons.refresh),
             onPressed: () => _resetChat(ref),
+          ),
+          IconButton(
+            icon: const Icon(Icons.play_arrow),
+            onPressed: () => _playChatHistory(ref),
+          ),
+          IconButton(
+            icon: const Icon(Icons.pause),
+            onPressed: () => _pauseTTS(ref),
+          ),
+          IconButton(
+            icon: const Icon(Icons.play_arrow),
+            onPressed: () => _resumeTTS(ref),
+          ),
+          IconButton(
+            icon: const Icon(Icons.stop),
+            onPressed: () => _stopTTS(ref),
           ),
         ],
       ),

--- a/lib/features/chat/pages/widgets/message_bubble.dart
+++ b/lib/features/chat/pages/widgets/message_bubble.dart
@@ -17,7 +17,7 @@ class MessageBubble extends ConsumerWidget {
     return GestureDetector(
       onTap: () async {
         // TTSプロバイダーを使用してメッセージを再生
-        await ref.read(ttsNotifierProvider.notifier).speak(message.text);
+        await ref.read(ttsNotifierProvider.notifier).speak(message);
       },
       child: Align(
         alignment:

--- a/lib/features/chat/providers/chat_provider.dart
+++ b/lib/features/chat/providers/chat_provider.dart
@@ -114,6 +114,9 @@ class ChatNotifier extends _$ChatNotifier {
 
       // 新しいチャット状態を初期化
       state = [];
+      
+      // Clear the pause state
+      await ref.read(ttsNotifierProvider.notifier).stop();
     } catch (e) {
       // エラーメッセージを追加
       state = [
@@ -125,5 +128,9 @@ class ChatNotifier extends _$ChatNotifier {
         ),
       ];
     }
+  }
+
+  List<String> getChatHistory() {
+    return state.map((message) => message.text).toList();
   }
 }

--- a/lib/features/chat/providers/chat_provider.dart
+++ b/lib/features/chat/providers/chat_provider.dart
@@ -89,7 +89,7 @@ class ChatNotifier extends _$ChatNotifier {
 
       // 完成したメッセージを読み上げ
       if (state.last.text.isNotEmpty) {
-        await ref.read(ttsNotifierProvider.notifier).speak(state.last.text);
+        await ref.read(ttsNotifierProvider.notifier).speak(state.last);
       }
     } catch (e) {
       // エラーメッセージを追加
@@ -114,7 +114,7 @@ class ChatNotifier extends _$ChatNotifier {
 
       // 新しいチャット状態を初期化
       state = [];
-      
+
       // Clear the pause state
       await ref.read(ttsNotifierProvider.notifier).stop();
     } catch (e) {


### PR DESCRIPTION
Implement chat history audio playback feature using flutter_tts.

* **lib/core/utils/provider/tts_provider.dart**
  - Add `speakChatHistory` method to iterate through the chat history and convert it to speech.
  - Add `pause`, `resume`, `stop`, and `setPlaybackPosition` methods for TTS playback control.

* **lib/features/chat/pages/chat_page.dart**
  - Add playback, pause, resume, and stop buttons to initiate and control chat history narration.
  - Update `_resetChat` method to clear the pause state.

* **lib/features/chat/providers/chat_provider.dart**
  - Add `getChatHistory` method to return the chat history.
  - Update `resetChat` method to clear the pause state.

