### PR TITLE
Implement chat history screen with search functionality

### DIFF
--- a/lib/core/components/footer.dart
+++ b/lib/core/components/footer.dart
@@ -1,4 +1,5 @@
 import 'package:ai_english/features/chat/pages/chat_page.dart';
+import 'package:ai_english/features/chat/pages/chat_history_page.dart';
 import 'package:flutter/material.dart';
 
 Widget footer(BuildContext context) {
@@ -15,6 +16,16 @@ Widget footer(BuildContext context) {
             Navigator.push(
               context,
               MaterialPageRoute(builder: (context) => ChatPage()),
+            );
+          },
+        ),
+        IconButton(
+          tooltip: 'Chat History',
+          icon: const Icon(Icons.history),
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => ChatHistoryPage()),
             );
           },
         ),

--- a/lib/core/utils/methods/format.dart
+++ b/lib/core/utils/methods/format.dart
@@ -1,0 +1,7 @@
+import 'package:intl/intl.dart';
+
+String formatDate(DateTime date) {
+  // UTCからJSTに変換（+9時間）
+  final jstDate = date.toLocal();
+  return DateFormat('yyyy/MM/dd', 'ja_JP').format(jstDate);
+}

--- a/lib/core/utils/provider/tts_provider.g.dart
+++ b/lib/core/utils/provider/tts_provider.g.dart
@@ -6,7 +6,7 @@ part of 'tts_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$ttsNotifierHash() => r'f29220de510ded3b4ed81347cc7f62a88def0a5c';
+String _$ttsNotifierHash() => r'bc452d23b2a021a70e443bf0cda84fc9df6b1753';
 
 /// See also [TtsNotifier].
 @ProviderFor(TtsNotifier)
@@ -20,5 +20,4 @@ final ttsNotifierProvider =
   allTransitiveDependencies: null,
 );
 
-// ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/chat/models/chat_history.dart
+++ b/lib/features/chat/models/chat_history.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'chat_history.freezed.dart';
+part 'chat_history.g.dart';
+
+@Freezed(unionKey: 'type', unionValueCase: FreezedUnionCase.snake)
+class ChatHistory with _$ChatHistory {
+  const factory ChatHistory({
+    required String id,
+    required String title,
+    required DateTime created_at,
+  }) = _ChatHistory;
+
+  factory ChatHistory.fromJson(Map<String, dynamic> json) =>
+      _$ChatHistoryFromJson(json);
+}

--- a/lib/features/chat/models/chat_history.freezed.dart
+++ b/lib/features/chat/models/chat_history.freezed.dart
@@ -1,0 +1,201 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'chat_history.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+ChatHistory _$ChatHistoryFromJson(Map<String, dynamic> json) {
+  return _ChatHistory.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ChatHistory {
+  String get id => throw _privateConstructorUsedError;
+  String get title => throw _privateConstructorUsedError;
+  DateTime get created_at => throw _privateConstructorUsedError;
+
+  /// Serializes this ChatHistory to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of ChatHistory
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ChatHistoryCopyWith<ChatHistory> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ChatHistoryCopyWith<$Res> {
+  factory $ChatHistoryCopyWith(
+          ChatHistory value, $Res Function(ChatHistory) then) =
+      _$ChatHistoryCopyWithImpl<$Res, ChatHistory>;
+  @useResult
+  $Res call({String id, String title, DateTime created_at});
+}
+
+/// @nodoc
+class _$ChatHistoryCopyWithImpl<$Res, $Val extends ChatHistory>
+    implements $ChatHistoryCopyWith<$Res> {
+  _$ChatHistoryCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ChatHistory
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? created_at = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      created_at: null == created_at
+          ? _value.created_at
+          : created_at // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ChatHistoryImplCopyWith<$Res>
+    implements $ChatHistoryCopyWith<$Res> {
+  factory _$$ChatHistoryImplCopyWith(
+          _$ChatHistoryImpl value, $Res Function(_$ChatHistoryImpl) then) =
+      __$$ChatHistoryImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String id, String title, DateTime created_at});
+}
+
+/// @nodoc
+class __$$ChatHistoryImplCopyWithImpl<$Res>
+    extends _$ChatHistoryCopyWithImpl<$Res, _$ChatHistoryImpl>
+    implements _$$ChatHistoryImplCopyWith<$Res> {
+  __$$ChatHistoryImplCopyWithImpl(
+      _$ChatHistoryImpl _value, $Res Function(_$ChatHistoryImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ChatHistory
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? created_at = null,
+  }) {
+    return _then(_$ChatHistoryImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      created_at: null == created_at
+          ? _value.created_at
+          : created_at // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ChatHistoryImpl implements _ChatHistory {
+  const _$ChatHistoryImpl(
+      {required this.id, required this.title, required this.created_at});
+
+  factory _$ChatHistoryImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ChatHistoryImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String title;
+  @override
+  final DateTime created_at;
+
+  @override
+  String toString() {
+    return 'ChatHistory(id: $id, title: $title, created_at: $created_at)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ChatHistoryImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.created_at, created_at) ||
+                other.created_at == created_at));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, title, created_at);
+
+  /// Create a copy of ChatHistory
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ChatHistoryImplCopyWith<_$ChatHistoryImpl> get copyWith =>
+      __$$ChatHistoryImplCopyWithImpl<_$ChatHistoryImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ChatHistoryImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ChatHistory implements ChatHistory {
+  const factory _ChatHistory(
+      {required final String id,
+      required final String title,
+      required final DateTime created_at}) = _$ChatHistoryImpl;
+
+  factory _ChatHistory.fromJson(Map<String, dynamic> json) =
+      _$ChatHistoryImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get title;
+  @override
+  DateTime get created_at;
+
+  /// Create a copy of ChatHistory
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ChatHistoryImplCopyWith<_$ChatHistoryImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/chat/models/chat_history.g.dart
+++ b/lib/features/chat/models/chat_history.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_history.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ChatHistoryImpl _$$ChatHistoryImplFromJson(Map<String, dynamic> json) =>
+    _$ChatHistoryImpl(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      created_at: DateTime.parse(json['created_at'] as String),
+    );
+
+Map<String, dynamic> _$$ChatHistoryImplToJson(_$ChatHistoryImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'created_at': instance.created_at.toIso8601String(),
+    };

--- a/lib/features/chat/pages/chat_history_page.dart
+++ b/lib/features/chat/pages/chat_history_page.dart
@@ -1,71 +1,16 @@
+import 'package:ai_english/core/utils/methods/format.dart';
+import 'package:ai_english/features/chat/providers/chat_history_provider.dart';
 import 'package:flutter/material.dart';
-import 'package:ai_english/core/http/api_client.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
 
-class ChatHistoryPage extends ConsumerStatefulWidget {
+class ChatHistoryPage extends ConsumerWidget {
   const ChatHistoryPage({super.key});
 
   @override
-  ChatHistoryPageState createState() => ChatHistoryPageState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final data = ref.watch(asyncChatHistoryProvider);
+    final notifier = ref.read(asyncChatHistoryProvider.notifier);
 
-class ChatHistoryPageState extends ConsumerState<ChatHistoryPage> {
-  final ApiClient _apiClient = ApiClient();
-  List<Map<String, dynamic>> _conversations = [];
-  List<Map<String, dynamic>> _filteredConversations = [];
-  bool _isLoading = true;
-  bool _isError = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _fetchConversations();
-  }
-
-  Future<void> _fetchConversations() async {
-    setState(() {
-      _isLoading = true;
-      _isError = false;
-    });
-
-    try {
-      final response = await _apiClient.get('/english/conversation_sets');
-      final data = response.data['sets'] as List<dynamic>;
-
-      setState(() {
-        _conversations = data.map((item) {
-          final createdAt = DateTime.parse(item['created_at']).toLocal();
-          final formattedDate = DateFormat('yyyy/MM/dd').format(createdAt);
-          return {
-            'id': item['id'],
-            'title': item['title'],
-            'created_at': formattedDate,
-          };
-        }).toList();
-        _filteredConversations = _conversations;
-        _isLoading = false;
-      });
-    } catch (e) {
-      setState(() {
-        _isError = true;
-        _isLoading = false;
-      });
-    }
-  }
-
-  void _filterConversations(String keyword) {
-    setState(() {
-      _filteredConversations = _conversations
-          .where((conversation) => conversation['title']
-              .toLowerCase()
-              .contains(keyword.toLowerCase()))
-          .toList();
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Chat History'),
@@ -79,27 +24,28 @@ class ChatHistoryPageState extends ConsumerState<ChatHistoryPage> {
                 labelText: 'Search',
                 border: OutlineInputBorder(),
               ),
-              onChanged: _filterConversations,
+              onChanged: notifier.filterConversations,
             ),
           ),
           Expanded(
-            child: _isLoading
-                ? const Center(child: CircularProgressIndicator())
-                : _isError
-                    ? const Center(child: Text('Failed to load conversations'))
-                    : ListView.builder(
-                        itemCount: _filteredConversations.length,
-                        itemBuilder: (context, index) {
-                          final conversation = _filteredConversations[index];
-                          return ListTile(
-                            title: Text(conversation['title']),
-                            subtitle: Text(conversation['created_at']),
-                            onTap: () {
-                              debugPrint('Tap message');
-                            },
-                          );
-                        },
-                      ),
+            child: data.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (error, _) =>
+                  Center(child: Text('Failed to load conversations')),
+              data: (chatHistories) => ListView.builder(
+                itemCount: chatHistories.length,
+                itemBuilder: (context, index) {
+                  final chatHistory = chatHistories[index];
+                  return ListTile(
+                    title: Text(chatHistory.title),
+                    subtitle: Text(formatDate(chatHistory.created_at)),
+                    onTap: () {
+                      debugPrint('Tap message');
+                    },
+                  );
+                },
+              ),
+            ),
           ),
         ],
       ),

--- a/lib/features/chat/pages/chat_history_page.dart
+++ b/lib/features/chat/pages/chat_history_page.dart
@@ -36,12 +36,21 @@ class ChatHistoryPage extends ConsumerWidget {
                 itemCount: chatHistories.length,
                 itemBuilder: (context, index) {
                   final chatHistory = chatHistories[index];
-                  return ListTile(
-                    title: Text(chatHistory.title),
-                    subtitle: Text(formatDate(chatHistory.created_at)),
-                    onTap: () {
-                      debugPrint('Tap message');
-                    },
+                  return Container(
+                    decoration: BoxDecoration(
+                      border: Border(
+                        bottom: BorderSide(
+                          color: Theme.of(context).dividerColor,
+                        ),
+                      ),
+                    ),
+                    child: ListTile(
+                      title: Text(chatHistory.title),
+                      subtitle: Text(formatDate(chatHistory.created_at)),
+                      onTap: () {
+                        debugPrint('Tap message');
+                      },
+                    ),
                   );
                 },
               ),

--- a/lib/features/chat/pages/chat_history_page.dart
+++ b/lib/features/chat/pages/chat_history_page.dart
@@ -1,16 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:ai_english/core/http/api_client.dart';
-import 'package:intl/intl.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
 
 class ChatHistoryPage extends ConsumerStatefulWidget {
-  const ChatHistoryPage({Key? key}) : super(key: key);
+  const ChatHistoryPage({super.key});
 
   @override
-  _ChatHistoryPageState createState() => _ChatHistoryPageState();
+  ChatHistoryPageState createState() => ChatHistoryPageState();
 }
 
-class _ChatHistoryPageState extends ConsumerState<ChatHistoryPage> {
+class ChatHistoryPageState extends ConsumerState<ChatHistoryPage> {
   final ApiClient _apiClient = ApiClient();
   List<Map<String, dynamic>> _conversations = [];
   List<Map<String, dynamic>> _filteredConversations = [];
@@ -57,8 +57,9 @@ class _ChatHistoryPageState extends ConsumerState<ChatHistoryPage> {
   void _filterConversations(String keyword) {
     setState(() {
       _filteredConversations = _conversations
-          .where((conversation) =>
-              conversation['title'].toLowerCase().contains(keyword.toLowerCase()))
+          .where((conversation) => conversation['title']
+              .toLowerCase()
+              .contains(keyword.toLowerCase()))
           .toList();
     });
   }

--- a/lib/features/chat/pages/chat_history_page.dart
+++ b/lib/features/chat/pages/chat_history_page.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:ai_english/core/http/api_client.dart';
+import 'package:intl/intl.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ChatHistoryPage extends ConsumerStatefulWidget {
+  const ChatHistoryPage({Key? key}) : super(key: key);
+
+  @override
+  _ChatHistoryPageState createState() => _ChatHistoryPageState();
+}
+
+class _ChatHistoryPageState extends ConsumerState<ChatHistoryPage> {
+  final ApiClient _apiClient = ApiClient();
+  List<Map<String, dynamic>> _conversations = [];
+  List<Map<String, dynamic>> _filteredConversations = [];
+  bool _isLoading = true;
+  bool _isError = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchConversations();
+  }
+
+  Future<void> _fetchConversations() async {
+    setState(() {
+      _isLoading = true;
+      _isError = false;
+    });
+
+    try {
+      final response = await _apiClient.get('/english/conversation_sets');
+      final data = response.data['sets'] as List<dynamic>;
+
+      setState(() {
+        _conversations = data.map((item) {
+          final createdAt = DateTime.parse(item['created_at']).toLocal();
+          final formattedDate = DateFormat('yyyy/MM/dd').format(createdAt);
+          return {
+            'id': item['id'],
+            'title': item['title'],
+            'created_at': formattedDate,
+          };
+        }).toList();
+        _filteredConversations = _conversations;
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _isError = true;
+        _isLoading = false;
+      });
+    }
+  }
+
+  void _filterConversations(String keyword) {
+    setState(() {
+      _filteredConversations = _conversations
+          .where((conversation) =>
+              conversation['title'].toLowerCase().contains(keyword.toLowerCase()))
+          .toList();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Chat History'),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: TextField(
+              decoration: const InputDecoration(
+                labelText: 'Search',
+                border: OutlineInputBorder(),
+              ),
+              onChanged: _filterConversations,
+            ),
+          ),
+          Expanded(
+            child: _isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : _isError
+                    ? const Center(child: Text('Failed to load conversations'))
+                    : ListView.builder(
+                        itemCount: _filteredConversations.length,
+                        itemBuilder: (context, index) {
+                          final conversation = _filteredConversations[index];
+                          return ListTile(
+                            title: Text(conversation['title']),
+                            subtitle: Text(conversation['created_at']),
+                            onTap: () {
+                              debugPrint('Tap message');
+                            },
+                          );
+                        },
+                      ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/chat/providers/chat_history_provider.dart
+++ b/lib/features/chat/providers/chat_history_provider.dart
@@ -1,0 +1,51 @@
+import 'package:ai_english/core/http/api_client.dart';
+import 'package:ai_english/features/chat/models/chat_history.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'chat_history_provider.g.dart';
+
+@riverpod
+class AsyncChatHistory extends _$AsyncChatHistory {
+  late final ApiClient _apiClient;
+  List<ChatHistory>? _originalChatHistories;
+
+  @override
+  FutureOr<List<ChatHistory>> build() async {
+    _apiClient = ApiClient();
+    _originalChatHistories = await _fetchConversations();
+    return _originalChatHistories!;
+  }
+
+  Future<List<ChatHistory>> _fetchConversations() async {
+    try {
+      final response = await _apiClient.get('/english/conversation_sets');
+      var data = response.data as List<dynamic>;
+      return data.map((e) => ChatHistory.fromJson(e)).toList();
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  void filterConversations(String keyword) {
+    if (_originalChatHistories == null) return;
+
+    if (keyword.isEmpty) {
+      state = AsyncData(_originalChatHistories!);
+      return;
+    }
+
+    final lowercaseKeyword = keyword.toLowerCase();
+    final filteredList = _originalChatHistories!
+        .where((chat) => chat.title.toLowerCase().contains(lowercaseKeyword))
+        .toList();
+
+    state = AsyncData(filteredList);
+  }
+
+  // オプション: 検索をリセットするメソッド
+  void resetFilter() {
+    if (_originalChatHistories != null) {
+      state = AsyncData(_originalChatHistories!);
+    }
+  }
+}

--- a/lib/features/chat/providers/chat_history_provider.dart
+++ b/lib/features/chat/providers/chat_history_provider.dart
@@ -41,11 +41,4 @@ class AsyncChatHistory extends _$AsyncChatHistory {
 
     state = AsyncData(filteredList);
   }
-
-  // オプション: 検索をリセットするメソッド
-  void resetFilter() {
-    if (_originalChatHistories != null) {
-      state = AsyncData(_originalChatHistories!);
-    }
-  }
 }

--- a/lib/features/chat/providers/chat_history_provider.g.dart
+++ b/lib/features/chat/providers/chat_history_provider.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_history_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$asyncChatHistoryHash() => r'0686c3d9f3fe7163711ea3fa11d7029caa9c2623';
+
+/// See also [AsyncChatHistory].
+@ProviderFor(AsyncChatHistory)
+final asyncChatHistoryProvider = AutoDisposeAsyncNotifierProvider<
+    AsyncChatHistory, List<ChatHistory>>.internal(
+  AsyncChatHistory.new,
+  name: r'asyncChatHistoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$asyncChatHistoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$AsyncChatHistory = AutoDisposeAsyncNotifier<List<ChatHistory>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/chat/providers/chat_provider.g.dart
+++ b/lib/features/chat/providers/chat_provider.g.dart
@@ -6,7 +6,7 @@ part of 'chat_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$chatNotifierHash() => r'43392ed9131c72b22b3b9a01541ceeb4ea3e7045';
+String _$chatNotifierHash() => r'1797e85cbc1e530e097d2184816e06ecd2229be9';
 
 /// See also [ChatNotifier].
 @ProviderFor(ChatNotifier)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:ai_english/features/home/pages/home_page.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 void main() {
@@ -18,6 +19,15 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
+      localizationsDelegates: [
+        GlobalWidgetsLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: [
+        const Locale('en', 'US'),
+        const Locale('ja', 'JP'),
+      ],
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(
             seedColor: const Color.fromARGB(255, 255, 148, 55)),

--- a/memo.txt
+++ b/memo.txt
@@ -1,4 +1,4 @@
-adb reverse tcp:8080 tcp:8080
+adb reverse tcp:8000 tcp:8000
 コマンドをPowerShellで実行
 
 git checkout -b add-loading-indicator origin/add-loading-indicator

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -349,6 +349,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   io:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,23 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "88399e291da5f7e889359681a8f64b18c5123e03576b01f32a6a276611e511c3"
+      sha256: dc27559385e905ad30838356c5f5d574014ba39872d732111cd07ac0beff4c57
       url: "https://pub.dev"
     source: hosted
-    version: "78.0.0"
-  _macros:
-    dependency: transitive
-    description: dart
-    source: sdk
-    version: "0.3.3"
+    version: "80.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "62899ef43d0b962b056ed2ebac6b47ec76ffd003d5f7c4e4dc870afe63188e33"
+      sha256: "192d1c5b944e7e53b24b5586db760db934b177d4147c42fbca8c8c5f1eb8d11e"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.3.0"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -74,26 +69,26 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "294a2edaf4814a378725bfe6358210196f5ea37af89ecd81bfa32960113d4948"
+      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.3"
+    version: "4.0.4"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "99d3980049739a985cf9b21f30881f46db3ebc62c5b8d5e60e27440876b1ba1e"
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "2.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "74691599a5bc750dc96a6b4bfd48f7d9d66453eab04c7f4063134800d6a5c573"
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.14"
+    version: "2.4.15"
   build_runner_core:
     dependency: transitive
     description:
@@ -194,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: custom_lint_visitor
-      sha256: "14df0760dfa81b7b0c398c876045f4e4a343eb2c9d200c66163671dd3e337c1b"
+      sha256: "36282d85714af494ee2d7da8c8913630aa6694da99f104fb2ed4afcf8fc857d8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0+7.1.0"
+    version: "1.0.0+7.3.0"
   dart_style:
     dependency: transitive
     description:
@@ -259,6 +254,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -333,6 +333,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -353,10 +361,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -385,10 +393,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: b0a98230538fe5d0b60a22fb6bf1b6cb03471b53e3324ff6069c591679dd59c9
+      sha256: "81f04dee10969f89f604e1249382d46b97a1ccad53872875369622b5bfc9e58a"
       url: "https://pub.dev"
     source: hosted
-    version: "6.9.3"
+    version: "6.9.4"
   leak_tracker:
     dependency: transitive
     description:
@@ -429,14 +437,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  macros:
-    dependency: transitive
-    description:
-      name: macros
-      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
@@ -553,10 +553,10 @@ packages:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,10 @@ dependencies:
   flutter_tts: ^4.2.2
   uuid: ^4.5.1
   flutter_spinkit: ^5.1.0
-  intl: ^0.20.2
+  # flutter_localizationsが0.19.0を要求しているため、明示的に指定。
+  intl: 0.19.0
+  flutter_localizations:
+    sdk: flutter
 
 dev_dependencies:
   # Flutterのテストフレームワーク。単体テストやウィジェットテストの実行に使用。

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   flutter_tts: ^4.2.2
   uuid: ^4.5.1
   flutter_spinkit: ^5.1.0
+  intl: ^0.20.2
 
 dev_dependencies:
   # Flutterのテストフレームワーク。単体テストやウィジェットテストの実行に使用。


### PR DESCRIPTION
Add a new screen to display chat history with search functionality.

* **lib/features/chat/pages/chat_history_page.dart**
  - Create a new screen to display chat history with search functionality.
  - Fetch conversation data from the API endpoint `/english/conversation_sets`.
  - Display each conversation's title and creation date formatted as "YYYY/MM/DD" in Japan time zone.
  - Implement a search bar to filter conversations by keyword.
  - Handle loading and error states from API calls gracefully.
  - Trigger a debug print statement when a conversation is tapped.

* **lib/core/components/footer.dart**
  - Add a new icon button for Chat History.
  - Implement navigation to `ChatHistoryPage` on button press.

